### PR TITLE
Adicionar paradas nos terminais no raspador dos fretados

### DIFF
--- a/src/connection/fretados_model.py
+++ b/src/connection/fretados_model.py
@@ -1,5 +1,5 @@
 import json
-from database import DBconfig, get_db, DBCollections
+from database import get_db, DBCollections
 from raspador_fretados import tables_on_page, clean_bus_df
 
 def list_all():
@@ -11,7 +11,7 @@ def list_all():
         if response.explain()["executionStats"]["executionSuccess"]: # Procura nos Status se a operação deu Certo
             return response
     except Exception as e:
-        raise e 
+        raise e
 
 def next_bus(origem, destino, horario_solicitacao, horario_limite, dia_semana): # TODO
     """
@@ -19,12 +19,12 @@ def next_bus(origem, destino, horario_solicitacao, horario_limite, dia_semana): 
     Args:
         origem: Onde o usuário se encontra.
         destino: Onde o usuário deseja ir.
-        horario_solicitacao: Quando exatamente ele fez essa requisição ?. 
+        horario_solicitacao: Quando exatamente ele fez essa requisição ?.
         horario_limite: Qual a carência permitida ?20 minutos é o padrão.
     Returns:
         Cursor (tipo iterável) do pymongo com a resposta, que pode ser vazia.
     """
-    
+
     return _get_collection().find({
         "origem": origem,
         "destino": destino,
@@ -37,7 +37,7 @@ def find_by_linha(linha, dia_semana):
         Função que retorna todos os Fretados com base na linha
     """
     try:
-        response = _get_collection().find_one({ 
+        response = _get_collection().find_one({
             "linha": linha,
             "dias" : "SEMANA" if dia_semana < 5 else "SABADO"
         })
@@ -46,13 +46,13 @@ def find_by_linha(linha, dia_semana):
     except Exception as e:
         raise e
 
-def find_by_all_fields(linha ,origem, destino, hora_partida, hora_chegada, dia_semana):
+def find_by_all_fields(linha ,origem, destino, hora_partida, hora_chegada, dia_semana, desembarque_terminal_leste):
     """
         Função que retorna todos os fretados que satisfazem
         que possuem todos seus campos mapeados pela busca.
     """
     try:
-        response = _get_collection().find({ 
+        response = _get_collection().find({
             "linha" : linha,
             "origem" : origem,
             "destino" : destino,
@@ -126,20 +126,22 @@ def _get_collection():
 class FretadosModel:
     """
     Classe que Modela o Objeto de negócio Fretado
-    - dias:            Pode ser de dois valores 'SEMANA' e 'SABADO'
-    - origem:          Pode ser de dois valores 'SA' e 'SBC'
-    - destino:         Pode ser de dois valores 'SA' e 'SBC'
-    - hora_partida:    Pode ser do valor de um horário, tipo '8:25' ou 'N/A' caso não tenha valor
-    - hora_chegada:    Pode ser do valor de um horário, tipo '8:25' ou 'N/A' caso não tenha valor
-    - linha:           O número da linha de onibus, pode ter valores de 1 a 6
+    - dias:                       Pode ser de dois valores 'SEMANA' e 'SABADO'
+    - origem:                     Pode ser dos valores: 'SA' ou 'SBC' ou 'TERMINAL-SBC' (Obs.: não pode ser terminal leste pois é apenas desembarque, temos um campo especifico para isso)
+    - destino:                    Pode ser dos valores: 'SA' ou 'SBC' ou 'TERMINAL-SBC' (Obs.: não pode ser terminal leste pois é apenas desembarque, temos um campo especifico para isso)
+    - hora_partida:               Pode ser do valor de um horário, tipo '8:25' ou 'N/A' caso não tenha valor
+    - hora_chegada:               Pode ser do valor de um horário, tipo '8:25' ou 'N/A' caso não tenha valor
+    - desembarque_terminal_leste: Caso tenha desembarque no Terminal Leste é o valor de um horário, tipo '8:25', caso contrário, 'N/A'
+    - linha:                      O número da linha de onibus, pode ter valores de 1 a 6
     """
-    def __init__(self, dias, origem, destino, hora_partida, hora_chegada, linha) -> None:
-        self.dias = dias 
-        self.origem = origem 
-        self.destino = destino 
+    def __init__(self, dias, origem, destino, hora_partida, hora_chegada, desembarque_terminal_leste, linha) -> None:
+        self.dias = dias
+        self.origem = origem
+        self.destino = destino
         self.hora_partida = hora_partida
         self.hora_chegada = hora_chegada
+        self.desembarque_terminal_leste = desembarque_terminal_leste
         self.linha = linha
-    
+
     def __str__(self) -> str:
         return "Fretado da Linha: {} que parte de {} as {} e chega em {} as {}, operando durante (o/a) {}".format(self.linha,self.origem,self.destino,self.hora_partida,self.hora_chegada,self.dias)

--- a/src/connection/populate-fretados.py
+++ b/src/connection/populate-fretados.py
@@ -7,19 +7,18 @@ fretados_model.populate_database()
 
 # ##catalogo_model.populate_database()
 
-for item in usuario_model.list_all():
-    print(item)
-
-# # Listando tudo que foi recuperado
-# print("Listando todos os Fretados")
-# for item in fretados_model.list_all():
+# for item in usuario_model.list_all():
 #     print(item)
 
-tempo_limite = "24:00"
+print("Listando todos os Fretados")
+for item in fretados_model.list_all():
+    print(item)
+
+# tempo_limite = "24:00"
 
 #print(fretados_model.next_bus("SA","SBC",tempo))
-for item in fretados_model.next_bus("SA","SBC",tempo,tempo_limite,5):
-    print(item)
+# for item in fretados_model.next_bus("SA","SBC",tempo,tempo_limite,5):
+#     print(item)
 
 # print("Listando todos as turmas do catálogo")
 # for item in catalogo_model.list_all():

--- a/src/connection/raspador_fretados.py
+++ b/src/connection/raspador_fretados.py
@@ -5,64 +5,95 @@ BUS_PAGE = requests.get(BUS_URL).content
 tables_on_page = pd.read_html(BUS_PAGE)
 
 # O Resultado desse método deve ser um dataframe único com 6 colunas:
-#   - dias:            Pode ser de dois valores 'SEMANA' e 'SABADO'
-#   - origem:          Pode ser de dois valores 'SA' e 'SBC'
-#   - destino:         Pode ser de dois valores 'SA' e 'SBC'
-#   - hora_partida:    Pode ser do valor de um horário, tipo '8:25' ou 'N/A' caso não tenha valor
-#   - hora_chegada:    Pode ser do valor de um horário, tipo '8:25' ou 'N/A' caso não tenha valor
-#   - linha:           O número da linha de onibus, pode ter valores de 1 a 6
+#   - dias:                       Pode ser de dois valores 'SEMANA' e 'SABADO'
+#   - origem:                     Pode ser dos valores: 'SA' ou 'SBC' ou 'TERMINAL-SBC' (Obs.: não pode ser terminal leste pois é apenas desembarque, temos um campo especifico para isso)
+#   - destino:                    Pode ser dos valores: 'SA' ou 'SBC' ou 'TERMINAL-SBC' (Obs.: não pode ser terminal leste pois é apenas desembarque, temos um campo especifico para isso)
+#   - hora_partida:               Pode ser do valor de um horário, tipo '8:25' ou 'N/A' caso não tenha valor
+#   - hora_chegada:               Pode ser do valor de um horário, tipo '8:25' ou 'N/A' caso não tenha valor
+#   - desembarque_terminal_leste: Caso tenha desembarque no Terminal Leste é o valor de um horário, tipo '8:25', caso contrário, 'N/A'
+#   - linha:                      O número da linha de onibus, pode ter valores de 1 a 6
 
 def clean_bus_df(df):
-    # Drop 'Somente desembarque Terminal Leste' 'Somente desembarque Terminal Leste.1' 'Terminal SBC'
-    df[0] = df[0].drop("Somente desembarque Terminal Leste", axis='columns')
-    df[0] = df[0].drop("Somente desembarque Terminal Leste.1", axis='columns')
-    df[1] = df[1].drop("Terminal SBC", axis='columns')
-
-    dataframe_zero_a = df[0][["Linha", "Santo André Partida", "São Bernardo Chegada"]]
-    dataframe_zero_a = dataframe_zero_a.rename(columns={'Santo André Partida': 'hora_partida', 'São Bernardo Chegada': 'hora_chegada', 'Linha': 'linha'})
+    # Pega os fretados do dataframe[0] que vao de SA a SBC
+    dataframe_zero_a = df[0][["Linha", "Santo André Partida", "Somente desembarque Terminal Leste", "São Bernardo Chegada"]]
+    dataframe_zero_a = dataframe_zero_a.rename(columns={
+        'Santo André Partida': 'hora_partida',
+        'Somente desembarque Terminal Leste': 'desembarque_terminal_leste',
+        'São Bernardo Chegada': 'hora_chegada',
+        'Linha': 'linha',
+    })
     dataframe_zero_a['origem'] = "SA"
     dataframe_zero_a['destino'] = "SBC"
     dataframe_zero_a['dias'] = "SEMANA"
 
-    dataframe_zero_b = df[0][["Linha", "Partida", "Santo André Chegada"]]
-    dataframe_zero_b = dataframe_zero_b.rename(columns={'Partida': 'hora_partida', 'Santo André Chegada': 'hora_chegada', 'Linha': 'linha'})
+    # Pega os fretados do dataframe[0] que vao de SBC a SA
+    dataframe_zero_b = df[0][["Linha", "Partida", "Somente desembarque Terminal Leste.1", "Santo André Chegada"]]
+    dataframe_zero_b = dataframe_zero_b.rename(columns={
+        'Partida': 'hora_partida',
+        'Somente desembarque Terminal Leste.1': 'desembarque_terminal_leste',
+        'Santo André Chegada': 'hora_chegada',
+        'Linha': 'linha',
+    })
     dataframe_zero_b['origem'] = "SBC"
     dataframe_zero_b['destino'] = "SA"
     dataframe_zero_b['dias'] = "SEMANA"
 
-    dataframe_one = df[1]
-    dataframe_one = dataframe_one.rename(columns={'Campus SBC Partida': 'hora_partida', 'Campus SBC Chegada': 'hora_chegada', 'Linha': 'linha'})
-    dataframe_one['origem'] = "SBC"
-    dataframe_one['destino'] = "SBC"
-    dataframe_one['dias'] = "SEMANA"
+    # Pega os fretados do dataframe[1] que vao de SBC a TERMINAL-SBC
+    dataframe_one_a = df[1][["Linha", "Campus SBC Partida", "Terminal SBC"]]
+    dataframe_one_a = dataframe_one_a.rename(columns={
+        'Campus SBC Partida': 'hora_partida',
+        'Terminal SBC': 'hora_chegada',
+        'Linha': 'linha'
+    })
+    dataframe_one_a['origem'] = "SBC"
+    dataframe_one_a['destino'] = "TERMINAL-SBC"
+    dataframe_one_a['dias'] = "SEMANA"
+    dataframe_one_a['desembarque_terminal_leste'] = "N/A"
 
+    # Pega os fretados do dataframe[1] que vao de TERMINAL-SBC a SBC
+    dataframe_one_b = df[1][["Linha", "Terminal SBC", "Campus SBC Chegada"]]
+    dataframe_one_b = dataframe_one_b.rename(columns={
+        'Terminal SBC': 'hora_partida',
+        'Campus SBC Chegada': 'hora_chegada',
+        'Linha': 'linha'
+    })
+    dataframe_one_b['origem'] = "TERMINAL-SBC"
+    dataframe_one_b['destino'] = "SBC"
+    dataframe_one_b['dias'] = "SEMANA"
+    dataframe_one_b['desembarque_terminal_leste'] = "N/A"
+
+    # Pega os fretados do dataframe[2] que vao de SA a SBC
     dataframe_two_a = df[2][["Linha", "Santo André Partida", "São Bernardo Chegada"]]
     dataframe_two_a = dataframe_two_a.rename(columns={'Santo André Partida': 'hora_partida', 'São Bernardo Chegada': 'hora_chegada', 'Linha': 'linha'})
     dataframe_two_a['origem'] = "SA"
     dataframe_two_a['destino'] = "SBC"
     dataframe_two_a['dias'] = "SABADO"
+    dataframe_two_a['desembarque_terminal_leste'] = "N/A"
 
-    dataframe_two_b = df[2][["Linha", "Santo André Partida", "São Bernardo Chegada"]]
-    dataframe_two_b = dataframe_two_a.rename(columns={'Santo André Partida': 'hora_partida', 'São Bernardo Chegada': 'hora_chegada', 'Linha': 'linha'})
+    # Pega os fretados do dataframe[2] que vao de SBC a SA
+    dataframe_two_b = df[2][["Linha", "Partida", "Santo André Chegada"]]
+    dataframe_two_b = dataframe_two_b.rename(columns={'Partida': 'hora_partida', 'Santo André Chegada': 'hora_chegada', 'Linha': 'linha'})
     dataframe_two_b['origem'] = "SBC"
     dataframe_two_b['destino'] = "SA"
     dataframe_two_b['dias'] = "SABADO"
+    dataframe_two_b['desembarque_terminal_leste'] = "N/A"
 
+    # Concatena os dataframes resultantes
     parsed_dataframe = pd.concat([
         dataframe_zero_a,
         dataframe_zero_b,
-        dataframe_one,
+        dataframe_one_a,
+        dataframe_one_b,
         dataframe_two_a,
         dataframe_two_b,
     ])
 
+    # Substitui todos os valores '---' por 'N/A'
     for column in parsed_dataframe.columns:
         parsed_dataframe.loc[(parsed_dataframe[column] == "---"),column] = 'N/A'
 
-    # for column in parsed_dataframe.columns:
-    # if column == "hora_partida" or column == "hora_chegada":
-    #     parsed_dataframe[column] = parsed_dataframe[column].apply( lambda x : datetime.datetime(2022,1,1,int(x.split(":")[0]),int(x.split(":")[1])).isoformat() if x != "---" else "N/A")
-    #     parsed_dataframe.loc[(parsed_dataframe[column] == "---"),column] = 'N/A'
-
+    # Limpa o dataframe de linhas com hora_chegada ou hora_partida sem informação
+    parsed_dataframe = parsed_dataframe[parsed_dataframe.hora_chegada != 'N/A']
+    parsed_dataframe = parsed_dataframe[parsed_dataframe.hora_partida != 'N/A']
 
     return parsed_dataframe

--- a/src/connection/test_fretados_model.py
+++ b/src/connection/test_fretados_model.py
@@ -25,6 +25,7 @@ class TestFretadoModel(unittest.TestCase):
             "hora_chegada": "07:07",
             "origem":"test_insert_item_inserts",
             "destino":"test_insert_item_inserts",
+            "desembarque_terminal_leste": "N/A",
             "dias":"SEMANA"
         }
         try:
@@ -42,6 +43,7 @@ class TestFretadoModel(unittest.TestCase):
             "hora_chegada": "07:07",
             "origem":"test_insert_item_find",
             "destino":"test_insert_item_find",
+            "desembarque_terminal_leste": "N/A",
             "dias":"SEMANA"
         }
         try:
@@ -52,6 +54,7 @@ class TestFretadoModel(unittest.TestCase):
                 hora_chegada=bus["hora_chegada"],
                 origem=bus["origem"],
                 destino=bus["destino"],
+                desembarque_terminal_leste=bus["desembarque_terminal_leste"],
                 dia_semana=bus["dias"]
             )
             #self.assertGreater(len(list(response_find)), 0, "Ao inserir um elemento, este deve estar no banco.")
@@ -69,6 +72,7 @@ class TestFretadoModel(unittest.TestCase):
             "hora_chegada": "07:07",
             "origem":"test_insert_item_find_retrieve",
             "destino":"test_insert_item_find_retrieve",
+            "desembarque_terminal_leste": "N/A",
             "dias":"SEMANA"
         }
 
@@ -79,6 +83,7 @@ class TestFretadoModel(unittest.TestCase):
             hora_chegada=bus["hora_chegada"],
             origem=bus["origem"],
             destino=bus["destino"],
+            desembarque_terminal_leste=bus["desembarque_terminal_leste"],
             dia_semana=bus["dias"]
         )
         bus_retrieved = list(response)[0]
@@ -95,6 +100,7 @@ class TestFretadoModel(unittest.TestCase):
             "hora_chegada": "07:07",
             "origem":"test_insert_items_inserts",
             "destino":"test_insert_items_inserts",
+            "desembarque_terminal_leste": "N/A",
             "dias":"SEMANA"
         }
         bus_2 = {
@@ -103,6 +109,7 @@ class TestFretadoModel(unittest.TestCase):
             "hora_chegada": "07:07",
             "origem":"test_insert_items_inserts",
             "destino":"test_insert_items_inserts",
+            "desembarque_terminal_leste": "N/A",
             "dias":"SABADO"
         }
         bus = [ json.loads(json.dumps(bus)) for bus in [bus_1,bus_2]]


### PR DESCRIPTION
- Para as paradas do Terminal Leste, como é destino, mas não pode ser origem (já que é apenas desembarque), foi criado um novo campo `desembarque_terminal_leste` que pode ter um horário ou `N/A`.
- O terminal SBC realmente é um destino ou uma origem, então foi adicionada a possibilidade `TERMINAL-SBC` aos campos de origem ou destino
- Para testar esse PR, faça pull da branch, instale as dependencias se nao tiver feito isso antes e rode `python3 src/connection/populate-fretados.py` no root do projeto no terminal.